### PR TITLE
Fix timeframes

### DIFF
--- a/couchdb/lms/lib/views.js
+++ b/couchdb/lms/lib/views.js
@@ -100,19 +100,6 @@ exports.processed_courses = {
 				}
 			}
 
-			expiry = doc['timeframe']['end']['#text'];
-			if (expiry) {
-				d = new Date(expiry);
-				d.setFullYear(d.getFullYear() + 1);
-				expiry = d.toISOString();
-				expiry = expiry.substring(0, expiry.indexOf('T'));
-			}
-			data['dates'] = {
-				'begin': doc['timeframe']['begin']['#text'],
-				'end': doc['timeframe']['end']['#text'],
-				'expire': expiry
-			}
-
 			emit([data['code_info']['system'], data['code_info']['system_course_code']], data);
 		} else if (doc['type'] == 'member' && doc['role']['@roletype'] == '02') {
 			var code_info = lmsutils.course_code_parse(doc['membership_sourcedid']['id']);

--- a/couchdb/lms/lib/views.js
+++ b/couchdb/lms/lib/views.js
@@ -82,10 +82,9 @@ exports.processed_courses = {
 			if ('timeframe' in doc) {
 				expiry = doc['timeframe']['end']['#text'];
 				if (expiry) {
-					d = new Date(expiry);
-					d.setFullYear(d.getFullYear() + 1);
-					expiry = d.toISOString();
-					expiry = expiry.substring(0, expiry.indexOf('T'));
+					expiry_components = expiry.split('-');
+					expiry_components[0] = (parseInt(expiry_components[0]) + 1).toString();
+					expiry = expiry_components.join('-');
 				}
 				data['dates'] = {
 					'begin': doc['timeframe']['begin']['#text'],


### PR DESCRIPTION
Use simple string splitting, modification, and joining to derive the
course expiry date instead of a Date object. The JS engine on
data.ucalgary.ca is too old for the Date class to support ISO formatted
dates.